### PR TITLE
Add terraform scripts for the standard GKE cluster

### DIFF
--- a/standard-gke-cluster-nfs/.gitignore
+++ b/standard-gke-cluster-nfs/.gitignore
@@ -1,0 +1,38 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+# *.tfvars
+# .tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore transient lock info files created by terraform apply
+.terraform.tfstate.lock.info
+.terraform.lock.hcl
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/standard-gke-cluster-nfs/README.md
+++ b/standard-gke-cluster-nfs/README.md
@@ -1,0 +1,108 @@
+## Terraform scripts for a GKE Standard Cluster with an NFS disk
+
+### Prerequisites
+
+
+Install `gcloud` installed
+
+Have a GCP project available, check them with
+
+```
+gcloud projects list
+```
+
+Check the current project with
+
+```
+gcloud config list
+```
+
+Change the project if needed with:
+
+```
+gcloud config set project <PROJECT_ID>
+```
+
+Install terraform: follow Ubuntu/Debian in https://developer.hashicorp.com/terraform/install
+
+Install kubectl:
+- either [on its own](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management) or with [Docker Desktop](https://www.docker.com/products/docker-desktop/)
+
+### Get the code
+
+Clone the code using ssh ([generate the ssh key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent?platform=linux) and [add it to your GitHub account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account?tool=webui)):
+
+```
+git clone git@github.com:cms-dpoa/cloud-processing.git
+cd cloud-processing/standard-gke-cluster-nfs
+```
+
+### Create the cluster
+
+Set `project_id` and `region` in `terraform.tfvars` to the desired values.
+
+Initialize terraform:
+
+```
+terraform init
+```
+
+Check what will created:
+
+```
+terraform plan
+```
+
+Create the resources
+
+```
+terraform apply
+```
+
+### Check the cluster
+
+Connect to the cluster with
+
+```
+gcloud container clusters get-credentials <CLUSTER_NAME> --region <REGION> --project <PROJECT_ID>
+```
+
+The cluster name is `cluster-<N>` where `<N>` is `name` as defined in `terraform.tfvars`.
+
+Use `kubectl` to inspect the cluster, e.g.
+
+```
+kubectl get all
+```
+
+```
+kubectl get nodes
+```
+
+```
+kubectl get pv
+```
+
+```
+kubectl get ns
+```
+
+```
+kubectl get all -n argo
+```
+
+### Use the cluster
+
+Run the jobs (to be completed)
+
+### Destroy the resource
+
+Destroy resources with
+
+```
+terraform destroy
+```
+
+
+
+

--- a/standard-gke-cluster-nfs/deploy.tf
+++ b/standard-gke-cluster-nfs/deploy.tf
@@ -1,0 +1,165 @@
+resource "kubernetes_namespace" "namespace1" {
+  metadata {
+    name = "argo"
+  }
+}
+
+//  001-nfs-server
+resource "kubernetes_deployment" "nfs_server" {
+  metadata {
+    name      = "nfs-server-${var.name}"
+    namespace = kubernetes_namespace.namespace1.metadata.0.name
+  }
+  spec {
+    replicas = 1
+    selector {
+      match_labels = {
+        role = "nfs-server-${var.name}"
+      }
+    }
+    template {
+      metadata {
+        namespace = kubernetes_namespace.namespace1.metadata.0.name
+        labels = {
+          role = "nfs-server-${var.name}"
+        }
+      }
+      spec {
+        volume {
+          name = "mypvc"
+          gce_persistent_disk {
+            pd_name = "gce-nfs-disk-${var.name}"
+            fs_type = "ext4"
+          }
+        }
+        container {
+          name  = "nfs-server-${var.name}"
+          image = "gcr.io/google_containers/volume-nfs:0.8"
+          port {
+            name           = "nfs"
+            container_port = 2049
+          }
+          port {
+            name           = "mountd"
+            container_port = 20048
+          }
+          port {
+            name           = "rpcbind"
+            container_port = 111
+          }
+          volume_mount {
+            name       = "mypvc"
+            mount_path = "/exports"
+          }
+          security_context {
+            privileged = true
+          }
+        }
+      }
+    }
+  }
+  depends_on = [
+    google_container_node_pool.cluster1_nodes
+  ]
+}
+
+//  002-nfs-server-service
+resource "kubernetes_service" "nfs_server" {
+  metadata {
+    name      = "nfs-server-${var.name}"
+    namespace = kubernetes_namespace.namespace1.metadata.0.name
+  }
+  spec {
+    port {
+      name = "nfs"
+      port = 2049
+    }
+    port {
+      name = "mountd"
+      port = 20048
+    }
+    port {
+      name = "rpcbind"
+      port = 111
+    }
+    selector = {
+      role = "nfs-server-${var.name}"
+    }
+  }
+  depends_on = [
+    google_container_node_pool.cluster1_nodes
+  ]
+}
+
+//  003-pv-pvc
+resource "kubernetes_persistent_volume" "nfs_pv" {
+  metadata {
+    name = "nfs-${var.name}"
+  }
+  spec {
+    capacity = {
+      storage = var.persistent_claim_storage_request
+    }
+    access_modes       = ["ReadWriteMany"]
+    storage_class_name = "standard"
+    persistent_volume_source {
+      nfs {
+        server = resource.kubernetes_service.nfs_server.spec.0.cluster_ip
+        path   = "/"
+      }
+    }
+  }
+  depends_on = [
+    google_container_node_pool.cluster1_nodes
+  ]
+}
+
+//  003-pv
+resource "kubernetes_persistent_volume_claim" "nfs_pvc" {
+  metadata {
+    name      = "nfs-${var.name}"
+    namespace = kubernetes_namespace.namespace1.metadata.0.name
+  }
+  spec {
+    access_modes       = ["ReadWriteMany"]
+    storage_class_name = "standard"
+    resources {
+      requests = {
+        storage = var.persistent_claim_storage_request
+      }
+    }
+    volume_name = kubernetes_persistent_volume.nfs_pv.metadata.0.name
+  }
+  depends_on = [
+    kubernetes_persistent_volume.nfs_pv
+  ]
+}
+
+//  pv-pod
+resource "kubernetes_pod" "pv_pod" {
+  metadata {
+    name      = "pv-pod"
+    namespace = kubernetes_namespace.namespace1.metadata.0.name
+  }
+  spec {
+    volume {
+      name = "task-pv-storage"
+      persistent_volume_claim {
+        claim_name = "nfs-${var.name}"
+      }
+    }
+    container {
+      name    = "pv-container"
+      image   = "busybox"
+      command = ["tail", "-f", "/dev/null"]
+      volume_mount {
+        name       = "task-pv-storage"
+        mount_path = "/mnt/data"
+      }
+    }
+  }
+  depends_on = [
+    google_container_node_pool.cluster1_nodes, kubernetes_persistent_volume_claim.nfs_pvc, kubernetes_deployment.nfs_server, 
+    kubernetes_persistent_volume.nfs_pv, kubernetes_service.nfs_server
+  ]
+}

--- a/standard-gke-cluster-nfs/gke.tf
+++ b/standard-gke-cluster-nfs/gke.tf
@@ -1,0 +1,38 @@
+data "google_client_config" "default" {}
+
+resource "google_container_cluster" "cluster1" {
+  name     = "cluster-${var.name}"
+  location = var.region
+  remove_default_node_pool = true
+  initial_node_count       = 1 
+  deletion_protection      = false 
+}
+
+# Separately Managed Node Pool
+resource "google_container_node_pool" "cluster1_nodes" {
+  name       = google_container_cluster.cluster1.name
+  location   = var.region
+  cluster    = google_container_cluster.cluster1.name
+  node_count = var.gke_num_nodes
+
+  node_config {
+    # Google recommends custom service accounts that have cloud-platform scope and permissions granted via IAM Roles.
+    # service_account = google_service_account.default.email
+    machine_type = var.gke_machine_type
+    disk_size_gb = var.gke_node_disk_size
+    disk_type    = "pd-standard"
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform",
+    ]
+    labels = {
+      env = var.project_id
+    }
+  }
+}
+
+resource "google_compute_disk" "default" {
+  name = "gce-nfs-disk-${var.name}"
+  type = "pd-standard"
+  size = var.persistent_disk_size
+  zone  = var.region
+}

--- a/standard-gke-cluster-nfs/providers.tf
+++ b/standard-gke-cluster-nfs/providers.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "5.6.0"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+      version = "2.23.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "kubernetes" {
+  host                   = "https://${resource.google_container_cluster.cluster1.endpoint}"
+  cluster_ca_certificate = base64decode(resource.google_container_cluster.cluster1.master_auth.0.cluster_ca_certificate)
+  token                  = data.google_client_config.default.access_token
+}
+

--- a/standard-gke-cluster-nfs/terraform.tfvars
+++ b/standard-gke-cluster-nfs/terraform.tfvars
@@ -1,5 +1,5 @@
-project_id          = "tutorials-403317"
-region              = "europe-west4-a"
-name                = "3"
+project_id          = "<PROJECT_ID>"
+region              = "<REGION>"
+name                = "<NAME>"
 gke_num_nodes       = 6
 gke_machine_type    = "e2-standard-4"

--- a/standard-gke-cluster-nfs/terraform.tfvars
+++ b/standard-gke-cluster-nfs/terraform.tfvars
@@ -1,0 +1,5 @@
+project_id          = "tutorials-403317"
+region              = "europe-west4-a"
+name                = "3"
+gke_num_nodes       = 6
+gke_machine_type    = "e2-standard-4"

--- a/standard-gke-cluster-nfs/variables.tf
+++ b/standard-gke-cluster-nfs/variables.tf
@@ -1,0 +1,38 @@
+variable "project_id" {
+  description = "project id"
+}
+
+variable "region" {
+  description = "region"
+}
+
+variable "gke_num_nodes" {
+  default     = 3
+  description = "number of gke nodes"
+}
+
+variable "gke_machine_type" {
+  default     = "e2-highmem-4"
+  description = "GKE machine type"
+}
+
+variable "gke_node_disk_size" {
+  default     = 100
+  description = "GKE node disk size"
+}
+
+variable "persistent_disk_size" {
+  default     = 100
+  description = "Persistent disk size"
+}
+
+variable "persistent_claim_storage_request" {
+  default     = "100Gi"
+  description = "Persistent claim storage request"
+}
+
+variable "name" {
+  default     = "1"
+  description = "Cluster name"
+}
+


### PR DESCRIPTION
closes #4 

Adds terraform scripts to create the cluster.

Includes `.gitignore` to avoid uploading unnecessary files.