### PR TITLE
klp: Add a directory for the image cache example, closes #51

### DIFF
--- a/standard-gke-cluster-gcs-imgdisk/README.md
+++ b/standard-gke-cluster-gcs-imgdisk/README.md
@@ -1,0 +1,196 @@
+## Terraform scripts for a GKE Standard Cluster with a Google Cloud Storage (GCS) bucket and a secondary boot disk
+
+### Prerequisites
+
+
+Install `gcloud` installed
+
+Have a GCP project available, check them with
+
+```
+gcloud projects list
+```
+
+Check the current project with
+
+```
+gcloud config list
+```
+
+Change the project if needed with:
+
+```
+gcloud config set project <PROJECT_ID>
+```
+
+Install terraform: follow Ubuntu/Debian in https://developer.hashicorp.com/terraform/install
+
+Install kubectl:
+- either [on its own](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management) or with [Docker Desktop](https://www.docker.com/products/docker-desktop/)
+
+Note that a Google Cloud billing account needs to be created and assigned to the GCP project that will be used with this repository.
+
+In addition, several APIs will need to be enabled in Google Cloud, which can be done through the console or with the gcloud command:
+
+```
+gcloud services enable <SERVICE_NAME>
+```
+
+The APIs that might need to be enabled are:
+- serviceusage.googleapis.com (Service Usage API)
+- cloudresourcemanager.googleapis.com (Cloud Resource Manager API)
+- container.googleapis.com (Kubernetes Engine API)
+- compute.googleapis.com (Compute Engine API)
+
+([Generate a ssh key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent?platform=linux) and [add it to your GitHub account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account?tool=webui)), if not alreday done.
+
+Prepare the secondary boot disk.
+
+Create a bucket for the logs. This can be separate from the bucket for the output files, but it is created in the same way, see instructions below. Then use the code from [gke-disk-image-builder](https://github.com/GoogleCloudPlatform/ai-on-gke/tree/main/tools/gke-disk-image-builder) to build the disk. Note that the timeout time needs to be increased for the pfnano image (100m was enough).
+
+### Get the code
+
+Clone the code using:
+
+```
+git clone git@github.com:cms-dpoa/cloud-processing.git
+cd cloud-processing/standard-gke-cluster-gcs
+```
+
+### Create the bucket
+
+The bucket for the output files has to be created separately since it is not included in the terraform deployments.
+Please make sure to use the same location for the bucket as the project.
+With gcloud CLI, buckets can be created as following:
+
+```
+gcloud storage buckets create gs://<BUCKET_NAME> --location=<BUCKET_LOCATION>
+```
+
+To use the bucket, a service account and IAM policy binding have to be set up:
+
+1. Setting up service account:
+```
+gcloud iam service-accounts create bucket-access --project <project-name>
+```
+2. Creating IAM policy binding:
+```
+gcloud projects add-iam-policy-binding <project-name> --member "serviceAccount:bucket-access@<project-name>.iam.gserviceaccount.com" --role "roles/storage.objectAdmin"
+```
+
+More information can be found here: https://cloud.google.com/storage/docs/creating-buckets#storage-create-bucket-cli
+
+
+### Create the cluster
+
+Set `project_id`, `region` and `name` in `terraform.tfvars` to the desired values.
+The `project_id` is the id of your GCP project and can be found via gcloud CLI command `gcloud projects list` or in the Google Cloud console when selecting a project.
+As of now, Google cloud requires a zone rather than a region, so choose a zone for the `region`-variable.
+A zone is usually just the region name followed by -a,-b or -c, i.e. `us-west1-a` instead of `us-west1`.
+See regions and zones here: https://cloud.google.com/compute/docs/regions-zones
+
+The `name`-variable will be used to set the name of the gke cluster and other resources as in the following example: 
+
+```
+"cluster-<NAME>"
+```
+
+Initialize terraform:
+
+```
+terraform init
+```
+
+Check what will created:
+
+```
+terraform plan
+```
+
+Create the resources
+
+```
+terraform apply
+```
+
+### Check the cluster
+
+Connect to the cluster with
+
+```
+gcloud container clusters get-credentials <CLUSTER_NAME> --region <REGION> --project <PROJECT_ID>
+```
+
+The cluster name is `cluster-<NAME>` where `<NAME>` is `name` as defined in `terraform.tfvars`.
+
+Enable image streaming so that image can be read from the secondary boot disk prepared above.
+
+```
+gcloud container clusters update cluster-<NAME> --zone <REGION> --enable-image-streaming
+```
+
+Use `kubectl` to inspect the cluster, e.g.
+
+```
+kubectl get all
+```
+
+```
+kubectl get nodes
+```
+
+```
+kubectl get pv
+```
+
+```
+kubectl get ns
+```
+
+```
+kubectl get all -n argo
+```
+
+### Use the cluster
+
+Install the argo workflows CLI following the instructions in https://github.com/argoproj/argo-workflows/releases/
+
+The `argo` subdirectory has an example workflow:
+
+- argo_bucket_run.yaml: an example workflow with <N_JOBS> jobs.
+
+Change the bucket name in the workflow file to correspond to the bucket in use.
+In other words, set the bucket `value` in the .yaml file(s) according to the name of the storage bucket (`<BUCKET_NAME>`) that was created earlier for storing the processing outputs.
+
+Furthermore, the MiniAOD dataset that is to be processed is determined by its recid (record id). The placeholder `<RECID>` in the .yaml file(s) needs to be updated with the chosen recid value.
+The datasets with their recids can be found on `https://opendata.cern.ch/`.
+The recid is the number in the end of the url, so the following dataset: `https://opendata.cern.ch/record/30549` has the recid `30549`.
+
+Submit the job with this command after changing the filename to the desired workflow file:
+```
+argo submit argo_bucket_run.yaml -n argo 
+```
+
+### Download the output files
+Once the workflow is completed, the output files are transferred to the storage bucket.
+The files can be downloaded to a local machine either from within the google cloud console or with the following command:
+```
+gsutil -m cp -r gs://<BUCKET_NAME>/ .
+```
+The target directory can be set by replacing the dot with the desired local path.
+The bucket can be emptied with:
+```
+gsutil -m rm gs://<BUCKET_NAME>/**
+```
+Alternatively, the bucket can be completely deleted with:
+```
+gcloud storage rm --recursive gs://<BUCKET_NAME>
+```
+
+### Destroy the resources
+
+Destroy resources with
+
+```
+terraform destroy
+```

--- a/standard-gke-cluster-gcs-imgdisk/argo/argo_bucket_run.yaml
+++ b/standard-gke-cluster-gcs-imgdisk/argo/argo_bucket_run.yaml
@@ -1,0 +1,273 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: pfnano-process-
+spec:
+  entrypoint: cms-od-example
+  serviceAccountName: argo-service-account
+  
+  arguments:
+    parameters:
+    - name: startFile                                  
+      value: 1
+    - name: nEvents   
+      #FIXME 
+      # Number of events in the dataset to be processed                       
+      value: <N_EVENTS>
+    - name: recid
+      #FIXME
+      # Record id of the dataset to be processed
+      value: <RECID>
+    - name: nJobs
+      #FIXME 
+      # Number of jobs the processing workflow should be split into
+      value: <N_JOBS> 
+    - name: bucket
+      #FIXME 
+      # Name of cloud storage bucket for storing outputs
+      value: <BUCKET_NAME>
+
+  templates:
+  - name: cms-od-example
+    inputs:
+      parameters:
+      - name: startFile
+      - name: nEvents
+      - name: recid
+      - name: nJobs
+      - name: bucket
+    dag:
+      tasks:
+
+      - name: get-metadata
+        template: get-metadata-template
+        arguments:
+         parameters:
+          - name: recid
+            value: "{{inputs.parameters.recid}}"
+          - name: bucket
+            value: "{{inputs.parameters.bucket}}"
+          - name: dataType
+            value: "{{outputs.parameters.dataType}}"
+
+      - name: joblist
+        dependencies: [get-metadata]
+        template: joblist-template
+        arguments:
+         parameters:
+          - name: startFile
+            value: "{{inputs.parameters.startFile}}"
+          - name: nJobs
+            value: "{{inputs.parameters.nJobs}}"
+          - name: nEvents
+            value: "{{inputs.parameters.nEvents}}"
+          - name: totFiles
+            value: "{{tasks.get-metadata.outputs.result}}"
+
+      - name: runpfnano
+        dependencies: [joblist]
+        template: runpfnano-template
+        arguments:
+         parameters:
+          - name: recid
+            value: "{{inputs.parameters.recid}}"
+          - name: bucket
+            value: "{{inputs.parameters.bucket}}"
+          - name: dataType
+            value: "{{tasks.get-metadata.outputs.parameters.dataType}}"
+          - name: it
+            value: "{{item.it}}"
+          - name: firstFile
+            value: "{{item.firstfile}}"
+          - name: lastFile
+            value: "{{item.lastfile}}" 
+          - name: eventsInJob
+            value: "{{item.eventsinjob}}"
+        withParam: "{{tasks.joblist.outputs.result}}"
+      
+      - name: plot
+        dependencies: [runpfnano]
+        template: plot-template
+        arguments:
+         parameters:
+          - name: bucket
+            value: "{{inputs.parameters.bucket}}"
+
+  # Get the metadata of the dataset
+  # Accidentally showing three different ways of passing parameters/files btw the steps
+  # - the full list of files: write it to a file on the common disk mounted on /mnt/vol
+  # - the type of data: write it to the step's ouput parameter "{{tasks.get-metadata.outputs.parameters.dataType}}#   (through a temporary file /tmp/type.txt)
+  # - the total number of files which is the stdout output of this step and goes to {{tasks.get-metadata.outputs.result}}
+  - name: get-metadata-template
+    inputs:
+      parameters:
+      - name: recid
+      - name: bucket
+    outputs:
+      parameters:
+      - name: dataType
+        valueFrom:
+          default: "default"
+          path: /tmp/type.txt
+      artifacts:
+      - name: filelist
+        path: bucket
+        gcs:
+          bucket: "{{inputs.parameters.bucket}}"
+          key: pfnano/files_{{inputs.parameters.recid}}.txt
+    script:
+      image: cernopendata/cernopendata-client
+      command: [bash]
+      source: |
+        mkdir bucket
+        cernopendata-client get-file-locations --recid "{{inputs.parameters.recid}}" --protocol xrootd > bucket/files_{{inputs.parameters.recid}}.txt;
+        cernopendata-client get-metadata --recid "{{inputs.parameters.recid}}"  --output-value type.secondary > /tmp/type.txt 
+        cernopendata-client get-metadata --recid "{{inputs.parameters.recid}}"  --output-value distribution.number_files
+        
+  # Generate the iterator list for the scatter step
+  # Compute the number of events and files for each step
+  # Write out the list with first and last filenumbers and the numebr of events to be taken as the input of the following steps
+  # (see {{tasks.joblist.outputs.result}} as "withParam" in runpfnano-template)
+  - name: joblist-template
+    inputs:
+      parameters:
+      - name: nJobs
+      - name: nEvents
+      - name: startFile
+      - name: totFiles
+    script:
+      image: python:alpine3.6
+      command: [python]
+      source: |
+        import json
+        import sys
+        start = {{inputs.parameters.startFile}}
+        nJobs = {{inputs.parameters.nJobs}}
+        nEvents = {{inputs.parameters.nEvents}}
+        totFiles = {{inputs.parameters.totFiles}}
+        filesInJob = int(totFiles/nJobs)
+        modFiles = totFiles % nJobs
+        eventsInJob = int(nEvents/nJobs)
+        modEvents = nEvents % nJobs
+        itlist = [i for i in range(1, nJobs+1)]
+        dictlist = []
+        for i in itlist:
+          first = start+(i-1)*filesInJob
+          last = first + filesInJob - 1
+          adict = { "it": i, 
+                    "firstfile": first, 
+                    "lastfile":  last,
+                    "eventsinjob": eventsInJob}
+          if i == nJobs:            
+            adict = { "it": i, 
+                      "firstfile": first, 
+                      "lastfile":  last + modFiles,
+                      "eventsinjob": eventsInJob + modEvents}
+          dictlist.append(adict)
+        json.dump(dictlist, sys.stdout)
+        
+  # Run the CMSSW step
+  # This iterates over the list that it gets as "withParam"
+  - name: runpfnano-template
+    inputs:
+      parameters:
+      - name: it
+      - name: firstFile
+      - name: lastFile
+      - name: recid
+      - name: bucket
+      - name: dataType
+      - name: eventsInJob
+      artifacts:
+      - name: bucket-input
+        path: /code/filelist
+        gcs:
+          bucket: "{{inputs.parameters.bucket}}"
+          key: pfnano/files_{{inputs.parameters.recid}}.txt
+    outputs:
+      artifacts:
+      - name: filelist
+        path: /code/scatter
+        archive:
+          none: {}
+        gcs:
+          bucket: "{{inputs.parameters.bucket}}"
+          key: pfnano/scatter/
+    script: 
+      image: ghcr.io/katilp/pfnano-image-build:main
+      command: [bash]
+      source: | 
+        
+        # sudo chown $USER /mnt/vol
+        mkdir /code/scatter
+        source /opt/cms/entrypoint.sh
+        eval `scramv1 runtime -sh`
+        # git clone https://github.com/cms-opendata-analyses/PFNanoProducerTool.git PhysicsTools/PFNano
+        cd /code/CMSSW_10_6_30/src/PhysicsTools/PFNano
+        # scram b
+
+        it="{{inputs.parameters.it}}"
+        eventsInJob="{{inputs.parameters.eventsInJob}}"
+        dataType="{{inputs.parameters.dataType}}"
+        echo Datatype $dataType
+        isData=False
+        if  echo $dataType | grep Collision ; then isData=True; fi
+
+        firstFile="{{inputs.parameters.firstFile}}"
+        lastFile="{{inputs.parameters.lastFile}}"
+        echo firstFile $firstFile
+        echo lastFile $lastFile
+
+        sed -i '/process.options.num/s/^/#/g' pfnano_data_2016UL_OpenData_cloud.py
+        sed -i "/process.load('FWCore.MessageService.MessageLogger_cfi')/a process.MessageLogger.cerr.FwkReport.reportEvery = 500" pfnano_data_2016UL_OpenData_cloud.py
+        sed -i "/from Configuration.AlCa.GlobalTag import GlobalTag/a process.GlobalTag.connect = cms.string('sqlite_file:/cvmfs/cms-opendata-conddb.cern.ch/106X_dataRun2_v37.db')" pfnano_data_2016UL_OpenData_cloud.py
+        
+        cms_start_time=$(date +%s)
+        cmsRun pfnano_data_2016UL_OpenData_cloud.py $firstFile $lastFile '"/code/filelist/files_{{inputs.parameters.recid}}.txt"' $eventsInJob
+        cms_end_time=$(date +%s)
+        job_duration=$((cms_end_time - cms_start_time))
+        echo "Job duration: Job $it took $(date -u -d @${job_duration} +'%H:%M:%S') to complete."
+        echo -e "Output file info: $(ls -lh nano_data2016.root)"
+        
+        mv nano_data2016.root /code/scatter/pfnanooutput$it.root
+
+      resources:
+        requests:
+          cpu: "800m"
+          memory: "1.5Gi"
+          ephemeral-storage: "5Gi"  
+
+  # prepare some histograms to check the output content
+  # the files are not merged, they are "chained" for ROOT
+  - name: plot-template   
+   
+    inputs:
+      parameters:
+      - name: bucket
+      artifacts:
+      - name: bucket-input
+        path: /code/scatter
+        gcs:
+          bucket: "{{inputs.parameters.bucket}}"
+          key: pfnano/scatter
+    outputs:
+      artifacts:
+      - name: plots
+        path: /code/plots
+        archive:
+          none: {}
+        gcs:
+          bucket: "{{inputs.parameters.bucket}}"
+          key: pfnano/plots/
+    script:
+      image: rootproject/root:latest
+      command: [bash]
+      source: | 
+        ls -l /code/scatter
+        curl -LO https://raw.githubusercontent.com/katilp/simple-root-chain-builder/main/makechain.sh
+        curl -LO https://raw.githubusercontent.com/katilp/simple-root-chain-builder/main/pfplots.C
+        source makechain.sh "/code/scatter/*.root" > mychain.C
+        root -b -l -q mychain.C pfplots.C
+        mkdir /code/plots
+        mv *.png /code/plots
+        

--- a/standard-gke-cluster-gcs-imgdisk/argo/argo_role.yaml
+++ b/standard-gke-cluster-gcs-imgdisk/argo/argo_role.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: argo
+  name: argo-service-account
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/log", "configmaps"]
+  verbs: ["get", "list", "watch", "create", "delete", "patch"]
+- apiGroups: ["argoproj.io"]
+  resources: ["workflows"]
+  verbs: ["get", "list", "watch", "create", "delete", "patch"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "list", "watch", "create", "update", "patch"]

--- a/standard-gke-cluster-gcs-imgdisk/argo/argo_role_binding.yaml
+++ b/standard-gke-cluster-gcs-imgdisk/argo/argo_role_binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argo-role-binding
+  namespace: argo
+subjects:
+- kind: ServiceAccount
+  name: argo-service-account
+  namespace: argo
+roleRef:
+  kind: Role
+  name: argo-service-account
+  apiGroup: rbac.authorization.k8s.io

--- a/standard-gke-cluster-gcs-imgdisk/argo/service_account.yaml
+++ b/standard-gke-cluster-gcs-imgdisk/argo/service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argo-service-account
+  namespace: argo

--- a/standard-gke-cluster-gcs-imgdisk/deploy.tf
+++ b/standard-gke-cluster-gcs-imgdisk/deploy.tf
@@ -1,0 +1,39 @@
+resource "kubernetes_namespace" "namespace1" {
+  metadata {
+    name = "argo"
+  }
+  depends_on = [
+    google_container_node_pool.cluster1_nodes
+  ]
+}
+
+# $ gcloud iam service-accounts add-iam-policy-binding bucket-access@<project-name>.iam.gserviceaccount.com --role roles/iam.workloadIdentityUser --member "serviceAccount:<project-name>.svc.id.goog[argo/default]"
+
+# SYNOPSIS
+#     gcloud iam service-accounts add-iam-policy-binding SERVICE_ACCOUNT
+#         --member=PRINCIPAL --role=ROLE
+#         [--condition=[KEY=VALUE,...]
+#           | --condition-from-file=CONDITION_FROM_FILE] [GCLOUD_WIDE_FLAG ...]
+
+
+# resource "google_service_account_iam_binding" "bucketbinding" {
+#   service_account_id = "bucket-access@.iam.gserviceaccount.com"
+#   role               = "roles/iam.workloadIdentityUser"<project-name>
+
+#   members = [
+#     "serviceAccount:<project-name>.svc.id.goog[argo/default]",
+#   ]
+# }
+
+# $ kubectl annotate serviceaccount default -n argo iam.gke.io/gcp-service-account=bucket-access@<project-name>.iam.gserviceaccount.com
+
+/* resource "kubernetes_annotations" "bucketannotation" {
+  api_version = "v1"
+  kind        = "ConfigMap"
+  metadata {
+    name = "my-config"
+  }
+  annotations = {
+    "owner" = "myteam"
+  }
+}§ */

--- a/standard-gke-cluster-gcs-imgdisk/gke.tf
+++ b/standard-gke-cluster-gcs-imgdisk/gke.tf
@@ -1,0 +1,46 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+# resource "google_service_account" "default" {
+#   account_id   = "service-account-id"
+#   display_name = "Service Account"
+# }
+
+data "google_client_config" "default" {}
+
+resource "google_container_cluster" "cluster1" {
+  name     = "cluster-${var.name}"
+  location = var.region
+  remove_default_node_pool = true
+  initial_node_count       = 1 
+  deletion_protection      = false
+}
+
+# Separately Managed Node Pool
+resource "google_container_node_pool" "cluster1_nodes" {
+  name       = google_container_cluster.cluster1.name
+  location   = var.region
+  cluster    = google_container_cluster.cluster1.name
+  node_count = var.gke_num_nodes
+
+  node_config {
+    # Google recommends custom service accounts that have cloud-platform scope and permissions granted via IAM Roles.
+    # service_account = google_service_account.default.email
+    machine_type = var.gke_machine_type
+    disk_size_gb = var.gke_node_disk_size
+    disk_type    = var.gke_node_disk_type
+    gcfs_config {
+      enabled = true
+    }
+    secondary_boot_disks {
+      disk_image = var.gke_image_disk_name
+      mode       = "CONTAINER_IMAGE_CACHE"
+    }
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform",
+    ]
+    labels = {
+      env = var.project_id
+    }
+  }
+}

--- a/standard-gke-cluster-gcs-imgdisk/outputs.tf
+++ b/standard-gke-cluster-gcs-imgdisk/outputs.tf
@@ -1,0 +1,34 @@
+output "region" {
+  value       = var.region
+  description = "GCloud Region"
+}
+
+output "project_id" {
+  value       = var.project_id
+  description = "GCloud Project ID"
+}
+
+output "kubernetes_cluster_name" {
+  value       = google_container_cluster.cluster1.name
+  description = "GKE Cluster Name"
+}
+
+output "kubernetes_cluster_host" {
+  value       = google_container_cluster.cluster1.endpoint
+  description = "GKE Cluster Host"
+}
+
+output "gke_num_nodes" {
+  value       = var.gke_num_nodes
+  description = "GKE cluster nodes"
+}
+
+output "gke_machine_type" {
+  value       = var.gke_machine_type
+  description = "GKE machine type"
+}
+
+output "gke_node_disk_size" {
+  value       = var.gke_node_disk_size
+  description = "GKE node disk size"
+}

--- a/standard-gke-cluster-gcs-imgdisk/providers.tf
+++ b/standard-gke-cluster-gcs-imgdisk/providers.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "6.3.0"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+      version = "2.32.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "kubernetes" {
+  host                   = "https://${resource.google_container_cluster.cluster1.endpoint}"
+  cluster_ca_certificate = base64decode(resource.google_container_cluster.cluster1.master_auth.0.cluster_ca_certificate)
+  token                  = data.google_client_config.default.access_token
+}
+

--- a/standard-gke-cluster-gcs-imgdisk/terraform.tfvars
+++ b/standard-gke-cluster-gcs-imgdisk/terraform.tfvars
@@ -1,0 +1,6 @@
+project_id          = "<PROJECT_ID>"
+region              = "<REGION>"
+name                = "<NAME>"
+gke_num_nodes       = <NUM_NODES>
+gke_machine_type    = "<MACHINE_TYPE>"
+gke_node_disk_type  = "<NODE_DISK_TYPE>

--- a/standard-gke-cluster-gcs-imgdisk/variables.tf
+++ b/standard-gke-cluster-gcs-imgdisk/variables.tf
@@ -1,0 +1,38 @@
+variable "project_id" {
+  description = "project id"
+}
+
+variable "region" {
+  description = "region"
+}
+
+variable "gke_num_nodes" {
+  default     = 2
+  description = "number of gke nodes"
+}
+
+variable "gke_machine_type" {
+  default     = "e2-standard-4"
+  description = "GKE machine type"
+}
+
+variable "gke_node_disk_size" {
+  default     = 100
+  description = "GKE node disk size"
+}
+
+variable "gke_node_disk_type" {
+  default     = "pd-standard"
+  description = "GKE node disk type"
+}
+
+variable "name" {
+  default     = "1"
+  description = "Cluster name"
+}
+
+variable "gke_image_disk_name" {
+  default     = "global/images/pfnano-disk-image"
+  description = "Secondary boot disk name"
+}
+


### PR DESCRIPTION
Differences compared to standard GCS:
- adds attributes to the node pool resource block so that the secondary boot disk is used
- removes the start workflow as not needed for container image pull
- updates readme
